### PR TITLE
Changed image processing to Base64 encoding for API compatibility

### DIFF
--- a/config/config.yaml.example
+++ b/config/config.yaml.example
@@ -26,7 +26,7 @@ activity:
 #---------------------------------------+
 #           Memory Management           |
 #---------------------------------------+
-mem_max: 4096 # tokens
+mem_max: 8096 # tokens
 mem_sync: 0.25 # 25% of capacity is synced
 
 

--- a/personalgpt.sh
+++ b/personalgpt.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # The PersonalGPT Project
-# Version: 3.0
+# Version: 3.2
 # This is the launch script for the PersonalGPT project.
 
 # Clear the terminal
@@ -9,7 +9,7 @@ clear
 
 # Output header information
 echo "The PersonalGPT Project"
-echo "Version: 3.0"
+echo "Version: 3.2"
 echo "This is the launch script for the PersonalGPT project."
 echo
 

--- a/src/cognition/response.py
+++ b/src/cognition/response.py
@@ -30,13 +30,13 @@ async def neural(message: discord.Message, client=client) -> str:
     """
     # Construct uplink
     uplink = await constructor(message=message)
-    
+
     try:
         response = await client.chat.completions.create(
             messages=uplink,
             model=constants.CHAT_MODEL,
             temperature=constants.CHAT_TEMP,
-            max_tokens=constants.CHAT_MAX,
+            max_completion_tokens=constants.CHAT_MAX,
         )
 
         return response.choices[0].message.content


### PR DESCRIPTION
**Project Version: 3.2**

This PR updates the image processing pipeline to encode images as Base64 strings before sending them to the API. This ensures compatibility with OpenAI's requirements for image uploads, as the API does not support Discord's CDN URLs for image attachments - or at least, doesn't do it reliably. 

![image](https://github.com/user-attachments/assets/6ac970de-9762-4393-9ee6-df8c9a9fd58a)

Key changes:  
- Added a helper function to fetch and encode images as Base64.  
- Integrated the Base64 encoding into the message assembly workflow.  
- Ensured transient handling of images to minimize memory usage.  

This change addresses issues with Discord URL access and improves overall reliability when handling image attachments.